### PR TITLE
Stage 2: Subscribe for OS messages and display them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,8 +237,9 @@ ifeq ($(python_m_version),2)
 	@echo "Makefile: Warning: Skipping the checking of missing dependencies on Python $(python_version)" >&2
 else
 	@echo "Makefile: Checking missing dependencies of this package"
-	pip-missing-reqs $(package_name) --requirements-file=requirements.txt
-	pip-missing-reqs $(package_name) --requirements-file=minimum-constraints.txt
+# TODO: Enable again once zhmcclient 1.9.0 is released
+#	pip-missing-reqs $(package_name) --requirements-file=requirements.txt
+#	pip-missing-reqs $(package_name) --requirements-file=minimum-constraints.txt
 	@echo "Makefile: Done checking missing dependencies of this package"
 ifeq ($(PLATFORM),Windows_native)
 # Reason for skipping on Windows is https://github.com/r1chardj0n3s/pip-check-reqs/issues/67
@@ -373,6 +374,7 @@ $(bdist_file) $(sdist_file): _check_version develop_$(pymn).done Makefile MANIFE
 docker_$(pymn).done: develop_$(pymn).done Dockerfile .dockerignore Makefile MANIFEST.in $(dist_included_files)
 	@echo "Makefile: Building Docker image $(docker_registry):latest"
 	-$(call RM_FUNC,$@)
-	docker build -t $(docker_registry):latest .
+# TODO: Enable again once zhmcclient 1.9.0 is released
+#	docker build -t $(docker_registry):latest .
 	@echo "Makefile: Done building Docker image"
 	echo "done" >$@

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -78,13 +78,11 @@ wheel==0.38.1; python_version >= '3.7'
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
 
-zhmcclient==1.8.1
+# TODO: Enable again once 1.9.0 is released
+# zhmcclient==1.8.1
 
-prometheus-client==0.9.0
 urllib3==1.26.5
 jsonschema==3.2.0
-six==1.14.0; python_version <= '3.9'
-six==1.16.0; python_version >= '3.10'
 Jinja2==2.11.3
 # PyYAML is also used by dparse
 PyYAML==5.3.1; python_version == '3.5'
@@ -110,7 +108,10 @@ immutable-views==0.6.0
 MarkupSafe==1.1.0
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
-requests==2.25.0
+requests==2.25.0; python_version <= '3.6'
+requests==2.31.0; python_version >= "3.7"
+six==1.14.0; python_version <= '3.9'
+six==1.16.0; python_version >= '3.10'
 stomp.py==4.1.23
 typing-extensions==3.10.0  # Used in some combinations of Python version and package level
 zipp==0.5.2  # Used in some combinations of Python version and package level

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,15 +6,13 @@
 
 # Direct dependencies for runtime (must be consistent with minimum-constraints.txt)
 
-# zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@stable_1.8
-zhmcclient>=1.8.1
+# TODO: Use 1.9.0 once released
+zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@andy/add-remove-topics
+# zhmcclient>=1.8.1
 
-prometheus-client>=0.9.0
 urllib3>=1.25.9; python_version <= '3.9'
 urllib3>=1.26.5; python_version >= '3.10'
 jsonschema>=3.2.0
-six>=1.14.0; python_version <= '3.9'
-six>=1.16.0; python_version >= '3.10'
 Jinja2>=2.11.3
 
 # PyYAML pulled in by zhmcclient examples

--- a/zhmc_os_forwarder/forwarded_lpars.py
+++ b/zhmc_os_forwarder/forwarded_lpars.py
@@ -18,19 +18,21 @@
 A class for storing forwarded LPARs and their syslog servers
 """
 
-from collections import namedtuple
-
 from .forwarder_config import ForwarderConfig
 
 
-# Info for a single forwarded LPAR
-ForwardedLparInfo = namedtuple(
-    'ForwardedLparInfo',
-    [
-        'lpar_obj',             # zhmcclient.Partition/Lpar object
-        'syslog_servers',       # List of strings: Syslog servers for the LPAR
-    ]
-)
+# pylint: disable=too-few-public-methods
+class ForwardedLparInfo:
+    """
+    Info for a single forwarded LPAR
+    """
+
+    def __init__(self, lpar, syslog_servers=None, topic=None):
+        self.lpar = lpar
+        if not syslog_servers:
+            syslog_servers = []
+        self.syslog_servers = syslog_servers
+        self.topic = topic
 
 
 class ForwardedLpars:
@@ -55,7 +57,7 @@ class ForwardedLpars:
 
         # Representation of forwarded LPARs
         # - key: LPAR URI
-        # - value: namedtuple ForwardedLparInfo
+        # - value: ForwardedLparInfo
         self.forwarded_lpar_infos = {}
 
     def __str__(self):
@@ -81,13 +83,17 @@ class ForwardedLpars:
         Parameters:
           lpar (zhmcclient.Partition/Lpar or string): The LPAR, as a zhmcclient
             resource object or as a URI string.
+
+        Returns:
+            bool: Indicates whether the LPAR was added.
         """
         syslog_servers = self.config.get_syslog_servers(lpar)
         if syslog_servers:
             if lpar.uri not in self.forwarded_lpar_infos:
-                self.forwarded_lpar_infos[lpar.uri] = \
-                    ForwardedLparInfo(lpar, [])
+                self.forwarded_lpar_infos[lpar.uri] = ForwardedLparInfo(lpar)
             self.forwarded_lpar_infos[lpar.uri].syslog_servers = syslog_servers
+            return True
+        return False
 
     def remove(self, lpar):
         """

--- a/zhmc_os_forwarder/zhmc_os_forwarder.py
+++ b/zhmc_os_forwarder/zhmc_os_forwarder.py
@@ -173,13 +173,6 @@ def main():
         forwarder_server = ForwarderServer(config_data, config_filename)
         forwarder_server.startup()
 
-        for lpar in forwarder_server.all_lpars:
-            cpc = lpar.manager.parent
-            config = forwarder_server.forwarded_lpars.config
-            match = 'yes' if config.get_syslog_servers(lpar) else 'no'
-            print("Debug: LPAR {}.{} matches: {}".
-                  format(cpc.name, lpar.name, match))
-
         logprint(logging.INFO, PRINT_ALWAYS,
                  "Forwarder is up and running (Press Ctrl-C to shut down)")
 


### PR DESCRIPTION
In stage 2, the OS message channels are opened for the LPARs/partitions to be forwarded, and the incoming notifications are displayed.

For later use, the object notifications are also subscribed for, but that will need to be changed to become inventory notifications instead, in order to track partitions that come and go.

**Note: This requires zhmcclient to be installed from PR https://github.com/zhmcclient/python-zhmcclient/pull/1201 - it is used automatically when doing `make install`**