### PR TITLE
Fixed issue with ignoring unpinned reqs with safety 3.0 and made that minimum

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -15,6 +15,10 @@ security:
     # Should be set to False.
     ignore-cvss-unknown-severity: False
 
+    # Ignore unpinned requirements.
+    # Should be set to False.
+    ignore-unpinned-requirements: False
+
     # List of specific vulnerabilities to ignore.
     # {id}:                 # vulnerability ID
     #     reason: {text}    # optional: Reason for ignoring it. Will be reported in the Safety reports

--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,9 @@ ifeq ($(python_version),3.6)
   check_reqs_packages := pip_check_reqs pipdeptree build pytest coverage coveralls flake8 pylint twine
 else
 ifeq ($(python_version),3.7)
-  check_reqs_packages := pip_check_reqs pipdeptree build pytest coverage coveralls flake8 pylint twine
+  check_reqs_packages := pip_check_reqs pipdeptree build pytest coverage coveralls flake8 pylint twine safety
 else
-  check_reqs_packages := pip_check_reqs pipdeptree build pytest coverage coveralls flake8 pylint twine sphinx
+  check_reqs_packages := pip_check_reqs pipdeptree build pytest coverage coveralls flake8 pylint twine safety sphinx
 endif
 endif
 
@@ -257,11 +257,15 @@ endif
 	@echo "Makefile: $@ done."
 
 $(done_dir)/safety_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done Makefile $(safety_policy_file) minimum-constraints.txt
+ifeq ($(python_version),3.6)
+	@echo "Makefile: Warning: Skipping Safety for all packages on Python $(python_version)" >&2
+else
 	@echo "Makefile: Running Safety"
 	-$(call RM_FUNC,$@)
 	safety check --policy-file $(safety_policy_file) -r minimum-constraints.txt --full-report
 	echo "done" >$@
 	@echo "Makefile: Done running Safety"
+endif
 
 .PHONY: test
 test: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,12 +10,9 @@ build>=0.5.0
 pep517>=0.9.1
 
 # Safety CI by pyup.io
-# Safety 2.3.5 (running only on Python >=3.6) requires packaging<22.0,>=21.0, but safety 2.3.4 does not
-#   and safety 2.4.0 will also no longer pin it (see https://github.com/pyupio/safety/issues/455).
-safety>=2.2.0,!=2.3.5
-dparse>=0.6.2
-ruamel.yaml>=0.17.21,<0.17.22; python_version == '3.6'
-ruamel.yaml>=0.17.21; python_version >= '3.7'
+# Safety is run only on Python >=3.7
+# Safety 3.0.0 requires exact versions of authlib==1.2.0 and jwt==1.3.1.
+safety>=3.0.1; python_version >= '3.7'
 
 # Unit test (imports into testcases):
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,13 @@ Released: not yet
 * Test: Added Python 3.8 with latest package levels to normal tests because
   that is now the minimum version to run Sphinx. (related to issue #57)
 
+* Test: Added the option 'ignore-unpinned-requirements: False' to both
+  safety policy files because for safety 3.0, the default is to ignore
+  unpinned requirements (in requirements.txt).
+  Increased safety minimum version to 3.0 because the new option is not
+  tolerated by safety 2.x. Safety now runs only on Python >=3.7 because
+  that is what safetx 3.0 requires.
+
 **Cleanup:**
 
 * Increased versions of GitHub Actions plugins to increase node.js runtime

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -70,7 +70,8 @@ requests==2.31.0; python_version >= '3.7'
 six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
 stomp.py==4.1.23
-typing-extensions==3.10.0  # Used in some combinations of Python version and package level
+typing-extensions==3.10.0; python_version == '3.6'
+typing-extensions==4.7.1; python_version >= '3.7'
 zipp==0.5.2  # Used in some combinations of Python version and package level
 
 # Direct dependencies for development (must be consistent with dev-requirements.txt)
@@ -81,9 +82,18 @@ build==0.5.0
 pep517==0.9.1
 
 # Safety CI by pyup.io
-safety==2.2.0
-dparse==0.6.2
-ruamel.yaml==0.17.21
+# Safety is run only on Python >=3.7
+safety==3.0.1; python_version >= '3.7'
+
+safety-schemas==0.0.1; python_version >= '3.7'
+# TODO: Change to dparse 0.6.4 once released
+dparse==0.6.4b0; python_version >= '3.7'
+ruamel.yaml==0.17.21; python_version >= '3.7'
+click==8.0.2; python_version >= '3.7'
+Authlib==1.2.0; python_version >= '3.7'
+marshmallow==3.15.0; python_version >= '3.7'
+pydantic==1.10.13; python_version >= '3.7'
+typer==0.9.0; python_version >= '3.7'
 
 # Unit test (imports into testcases):
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
@@ -186,7 +196,7 @@ gitdb==4.0.8
 html5lib==1.0.1  # used with minimum package levels
 imagesize==1.3.0
 iniconfig==1.1.1
-Jinja2==3.0.0; python_version == '3.6'
+Jinja2==3.0.3; python_version == '3.6'
 Jinja2==3.1.3; python_version >= '3.7'
 keyring==18.0.0
 more-itertools==8.0.0  # used with minimum package levels


### PR DESCRIPTION
For details, see the commit message.
No review needed.