### PR TITLE
Fixed coveralls not found on MacOS with py39-311

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,11 @@ jobs:
               }, \
               { \
                 \"os\": \"macos-latest\", \
+                \"python-version\": \"3.11\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
                 \"python-version\": \"3.12\", \
                 \"package_level\": \"minimum\" \
               }, \
@@ -195,7 +200,6 @@ jobs:
       run: |
         make docker
     - name: Send coverage result to coveralls.io
-      shell: bash -l {0}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ else
   RMDIR_R_FUNC = find . -type d -name '$(1)' | xargs -n 1 rm -rf
   CP_FUNC = cp -r $(1) $(2)
   ENV = env | sort
-  WHICH = which
+  WHICH = which -a
 endif
 
 package_name := zhmc_os_forwarder

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -52,6 +52,10 @@ Released: not yet
 * Docs: Fixed incorrect link to change log.
   (issue #30)
 
+* Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
+  with Python 3.9-3.11, by running it without login shell. Added Python 3.11 on
+  MacOS to the normal tests.
+
 **Enhancements:**
 
 * Changed development status of this package to "Beta".


### PR DESCRIPTION
Was reviewed in https://github.com/zhmcclient/python-zhmcclient/pull/1664 - no separate review needed.