### PR TITLE
Added handling of HTTP 422 for creating stable branch in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,8 +173,12 @@ jobs:
         INPUT_BODY: "Change log https://zhmc-os-forwarder.readthedocs.io/en/stable/changes.html"
 
     #-------- Creation of stable branch
+    # Note: This does not seem to depend on the disablement of the "Restrict pushes
+    # that create matching branches" setting in the branch protection rules for stable_*.
+    # It is possible that this fails with HTTP 422, for unknown reasons.
     - name: Create new stable branch when releasing master branch
       if: steps.set-is-master-branch.outputs.result == 'true'
+      id: create-stable-branch
       uses: actions/github-script@v7
       with:
         script: |
@@ -186,3 +190,32 @@ jobs:
           })
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
+    - name: Wait some time if HTTP error 422
+      if: steps.set-is-master-branch.outputs.result == 'true' and steps.create-stable-branch.outputs.status == 422
+      run: |
+        sleep 10
+    - name: Retry create new stable branch when releasing master branch if HTTP error 422
+      if: steps.set-is-master-branch.outputs.result == 'true' and steps.create-stable-branch.outputs.status == 422
+      id: create-stable-branch-2
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: "refs/heads/${{ steps.set-stable-branch.outputs.result }}",
+            sha: "${{ github.sha }}",
+          })
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
+    - name: Handle HTTP error 422 from creating the new stable branch
+      if: steps.set-is-master-branch.outputs.result == 'true' and steps.create-stable-branch-2.outputs.status == 422
+      run: |
+        echo "Error: Creating the new stable branch ${{ steps.set-stable-branch.outputs.result }} failed twice, but the publish still succeeded. Create the new stable branch manually:"
+        echo "git checkout master"
+        echo "git pull"
+        echo "git checkout -b ${{ steps.set-stable-branch.outputs.result }}"
+        echo "git push --set-upstream origin ${{ steps.set-stable-branch.outputs.result }}"
+        false

--- a/changes/noissue.http422.fix.rst
+++ b/changes/noissue.http422.fix.rst
@@ -1,0 +1,2 @@
+Dev: Added handling of HTTP error 422 when creating a new stable branch in
+the GitHub Actions publish workflow.


### PR DESCRIPTION
No review needed.

For details, see issue https://github.com/zhmcclient/zhmc-log-forwarder/issues/139