### PR TITLE
Fixed pip-missing-reqs TypeError by pinning pip to <26.2

### DIFF
--- a/changes/noissue.pipcheckreqs.fix.rst
+++ b/changes/noissue.pipcheckreqs.fix.rst
@@ -1,0 +1,2 @@
+Development: Fixed that pip-missing-reqs raised TypeError by pinning pip
+to <26.2.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -95,8 +95,7 @@ roman-numerals==4.1.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree==2.24.0
-pip-check-reqs==2.4.3; python_version <= '3.11'
-pip-check-reqs==2.5.1; python_version >= '3.12'
+pip-check-reqs==2.5.6
 
 
 # ------------------------------------------------------------------------------

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -10,7 +10,8 @@
 # and build-system.requires in pyproject.toml)
 
 pip>=26.0.1; python_version == '3.9'
-pip>=26.1.2; python_version >= '3.10'
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'
 setuptools>=78.1.1
 setuptools-scm[toml]>=9.2.0
 wheel>=0.46.2

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -98,7 +98,7 @@ Babel>=2.12.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree>=2.24.0
-# pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
-# pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
-pip-check-reqs>=2.4.3,!=2.5.0; python_version <= '3.11'
-pip-check-reqs>=2.5.1; python_version >= '3.12'
+pip-check-reqs>=2.5.6
+
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'


### PR DESCRIPTION
No review needed.