### PR TITLE
1.1: Fixed pip-missing-reqs TypeError by pinning pip to <26.2

### DIFF
--- a/changes/noissue.pipcheckreqs.fix.rst
+++ b/changes/noissue.pipcheckreqs.fix.rst
@@ -1,0 +1,2 @@
+Development: Fixed that pip-missing-reqs raised TypeError by pinning pip
+to <26.2.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -110,8 +110,8 @@ roman-numerals==4.1.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree==2.24.0
-pip-check-reqs==2.4.3; python_version <= '3.11'
-pip-check-reqs==2.5.1; python_version >= '3.12'
+pip-check-reqs==2.4.3; python_version == '3.8'
+pip-check-reqs==2.5.6; python_version >= '3.9'
 
 # towncrier depends on importlib-resources>=5, which is included in Python starting with 3.10
 importlib-resources==5.12.0; python_version <= '3.9'

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -8,7 +8,7 @@
 
 # Need to comment out pip==26.0.1 due to issue https://github.com/pyupio/safety/issues/847
 # pip==26.0.1; python_version == '3.9'
-pip==26.1; python_version >= '3.10'
+pip==26.1.2; python_version >= '3.10'
 setuptools==70.0.0; python_version == '3.8'
 setuptools==78.1.1; python_version >= '3.9'
 # Note on not specifying 'setuptools-scm[toml]': Extras cannot be in constraints files

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -9,8 +9,10 @@
 # Base dependencies (must be consistent with minimum-constraints-install.txt
 # and build-system.requires in pyproject.toml)
 
+pip>=25.0; python_version == '3.8'
 pip>=26.0.1; python_version == '3.9'
-pip>=26.1; python_version >= '3.10'
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'
 setuptools>=70.0.0; python_version == '3.8'
 setuptools>=78.1.1; python_version >= '3.9'
 setuptools-scm[toml]>=9.2.0

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -110,9 +110,13 @@ Babel>=2.11.0
 # Package dependency management tools (not used by any make rules)
 pipdeptree>=2.24.0
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
+# pip-check-reqs 2.5.0 dropped support for py38
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
-pip-check-reqs>=2.4.3,!=2.5.0; python_version <= '3.11'
-pip-check-reqs>=2.5.1; python_version >= '3.12'
+pip-check-reqs>=2.4.3,!=2.5.0; python_version == '3.8'
+pip-check-reqs>=2.5.6; python_version >= '3.9'
 
 # towncrier depends on importlib-resources>=5, which is included in Python starting with 3.10
 importlib-resources>=5.12.0; python_version <= '3.9'
+
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'


### PR DESCRIPTION
Backports #297 into 1.1.